### PR TITLE
JSONEncoder does not work with Arrays and Dictionary of JSONEncode protocol type

### DIFF
--- a/JSONCodableTests/HelperTests.swift
+++ b/JSONCodableTests/HelperTests.swift
@@ -23,6 +23,12 @@ class HelperTests: XCTestCase {
 
 		let notEncodableArray:[NotEncodable] = [NotEncodable()]
 		XCTAssert(!notEncodableArray.elementsAreJSONEncodable(), "Array of type [NotEncodable] should not be encodable")
+
+		let encoded = try? JSONEncoder.create({ (encoder) -> Void in
+			try encoder.encode(intArray, key: "intArray")
+			try encoder.encode(encodableArray, key: "encodableArray")
+		})
+
 	}
 
 	func testDictionaryIsEncodable() {
@@ -35,6 +41,10 @@ class HelperTests: XCTestCase {
 		let notEncodableDict:[String:NotEncodable] = ["a":NotEncodable()]
 		XCTAssert(!notEncodableDict.valuesAreJSONEncodable(), "Dictionary of type [String:NotEncodable] should not be encodable")
 
+		let encoded = try? JSONEncoder.create({ (encoder) -> Void in
+			try encoder.encode(intDict, key: "intArray")
+			try encoder.encode(encodableDict, key: "encodableArray")
+		})
 	}
     
 }


### PR DESCRIPTION
2.0 broke the support for arrays and dictionaries of JSONEncodable protocol type.
The additions to the test don't compile due to type issues…
