### PR TITLE
Make `get` public in JSONDecoder

### DIFF
--- a/JSONCodable/JSONDecodable.swift
+++ b/JSONCodable/JSONDecodable.swift
@@ -71,7 +71,7 @@ public class JSONDecoder {
         self.object = object
     }
     
-    private func get(key: String) -> AnyObject? {
+    public func get(key: String) -> AnyObject? {
         let keys = key.componentsSeparatedByString(".")
         
         let result = keys.reduce(object as AnyObject?) {


### PR DESCRIPTION
This allows for JSONDecoder extensions that allow the type system to better aid in decoding. For example, you could do:

``` swift
extension JSONDecoder {
    public func decode(key: String) throws -> NSURL {
        return decode(key, JSONTransformers.StringToNSURL)
    }
}
```

then you only need to do:

``` swift
try url = decoder.decode("url")
```

instead of

``` swift
try url = decoder.decode("url", JSONTransformers.StringToNSURL)
```

And with the proper extensions setup, you never need to specify _how_ to decode something at the call site unless there are multiple ways to decode a given type. As an example of a transformer that isn't built-in that we'd like this functionality for, we have a custom ID type that is convertible to/from a string, but don't want to have to manually specify the transformer each time we're decoding an ID.
