### PR TITLE
Ensure consistency for non-optional array types

### DIFF
--- a/JSONCodable/JSONDecodable.swift
+++ b/JSONCodable/JSONDecodable.swift
@@ -165,7 +165,7 @@ public class JSONDecoder {
     // [JSONCompatible]
     public func decode<Element: JSONCompatible>(key: String) throws -> [Element] {
         guard let value = get(key) else {
-            throw JSONDecodableError.MissingTypeError(key: key)
+            return []
         }
         guard let array = value as? [Element] else {
             throw JSONDecodableError.IncompatibleTypeError(key: key, elementType: value.dynamicType, expectedType: [Element].self)


### PR DESCRIPTION
Just like [JSONDecodable] and [Enum] types, [JSONCompatible] should return an empty array instead of throwing.
