### PR TITLE
Imported Foundation to fix compile error for WatchOS

### DIFF
--- a/JSONCodable/JSONDecodable.swift
+++ b/JSONCodable/JSONDecodable.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2015 matthewcheok. All rights reserved.
 //
 
+import Foundation
+
 // Decoding Errors
 
 public enum JSONDecodableError: ErrorType, CustomStringConvertible {


### PR DESCRIPTION
Build fails when building for WatchOS without importing Foundation

Use of undeclared type 'NSNull'
