### PR TITLE
Added option to encode null values

### DIFF
--- a/JSONCodable.playground/Contents.swift
+++ b/JSONCodable.playground/Contents.swift
@@ -105,7 +105,7 @@ We can instantiate `User` using one of provided initializers:
 - `init?(JSONString: String)`
 */
 
-let user = User(JSONDictionary: JSON)!
+var user = try! User(object: JSON)
 
 print("Decoded: \n\(user)\n\n")
 

--- a/JSONCodable.playground/Contents.swift
+++ b/JSONCodable.playground/Contents.swift
@@ -31,14 +31,14 @@ We'll add conformance to `JSONEncodable`. You may also add conformance to `JSONC
 */
 
 extension User: JSONEncodable {
-    func toJSON() throws -> AnyObject {
-        return try JSONEncoder.create({ (encoder) -> Void in
+    func toJSON(options: JSONEncodingOptions) throws -> AnyObject {
+        return try JSONEncoder.create(options) { (encoder) -> Void in
             try encoder.encode(id, key: "id")
             try encoder.encode(name, key: "full_name")
             try encoder.encode(email, key: "email")
             try encoder.encode(company, key: "company")
             try encoder.encode(friends, key: "friends")
-        })
+        }
     }
 }
 
@@ -116,7 +116,7 @@ And encode it to JSON using one of the provided methods:
 */
 
 do {
-    let dict = try user.toJSON()
+    let dict = try user.toJSON([])
     print("Encoded: \n\(dict as! JSONObject)\n\n")
 }
 catch {

--- a/JSONCodable.playground/Contents.swift
+++ b/JSONCodable.playground/Contents.swift
@@ -54,31 +54,21 @@ We'll add conformance to `JSONDecodable`. You may also add conformance to `JSONC
 */
 
 extension User: JSONDecodable {
-    init?(JSONDictionary: JSONObject) {
-        let decoder = JSONDecoder(object: JSONDictionary)
-        do {
-            id = try decoder.decode("id")
-            name = try decoder.decode("full_name")
-            email = try decoder.decode("email")
-            company = try decoder.decode("company")
-            friends = try decoder.decode("friends")
-        }
-        catch {
-            return nil
-        }
+    init(object: JSONObject) throws {
+        let decoder = JSONDecoder(object: object)
+        id = try decoder.decode("id")
+        name = try decoder.decode("full_name")
+        email = try decoder.decode("email")
+        company = try decoder.decode("company")
+        friends = try decoder.decode("friends")
     }
 }
 
 extension Company: JSONDecodable {
-    init?(JSONDictionary: JSONObject) {
-        let decoder = JSONDecoder(object: JSONDictionary)
-        do {
-            name = try decoder.decode("name")
-            address = try decoder.decode("address")
-        }
-        catch {
-            return nil
-        }
+    init(object: JSONObject) throws {
+        let decoder = JSONDecoder(object: object)
+        name = try decoder.decode("name")
+        address = try decoder.decode("address")
     }
 }
 

--- a/JSONCodable.playground/contents.xcplayground
+++ b/JSONCodable.playground/contents.xcplayground
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='5.0' target-platform='osx' requires-full-environment='true' display-mode='rendered'>
+<playground version='5.0' target-platform='osx' display-mode='rendered'>
     <timeline fileName='timeline.xctimeline'/>
 </playground>

--- a/JSONCodable.playground/timeline.xctimeline
+++ b/JSONCodable.playground/timeline.xctimeline
@@ -3,7 +3,7 @@
    version = "3.0">
    <TimelineItems>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=46&amp;CharacterRangeLoc=1747&amp;EndingColumnNumber=51&amp;EndingLineNumber=78&amp;StartingColumnNumber=5&amp;StartingLineNumber=78&amp;Timestamp=474555585.036027"
+         documentLocation = "#CharacterRangeLen=46&amp;CharacterRangeLoc=1785&amp;EndingColumnNumber=51&amp;EndingLineNumber=78&amp;StartingColumnNumber=5&amp;StartingLineNumber=78&amp;Timestamp=474577879.680475"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>

--- a/JSONCodable.playground/timeline.xctimeline
+++ b/JSONCodable.playground/timeline.xctimeline
@@ -2,5 +2,10 @@
 <Timeline
    version = "3.0">
    <TimelineItems>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "#CharacterRangeLen=46&amp;CharacterRangeLoc=1747&amp;EndingColumnNumber=51&amp;EndingLineNumber=78&amp;StartingColumnNumber=5&amp;StartingLineNumber=78&amp;Timestamp=474555585.036027"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
    </TimelineItems>
 </Timeline>

--- a/JSONCodable/JSONCodable.swift
+++ b/JSONCodable/JSONCodable.swift
@@ -22,7 +22,7 @@ extension Int: JSONCompatible {}
 extension NSNull: JSONCompatible {}
 
 extension JSONCompatible {
-    public func toJSON(encodeNulls encodeNulls: Bool) throws -> AnyObject {
+    public func toJSON(options: JSONEncodingOptions) throws -> AnyObject {
         return self as! AnyObject
     }
 }

--- a/JSONCodable/JSONCodable.swift
+++ b/JSONCodable/JSONCodable.swift
@@ -21,7 +21,7 @@ extension Bool: JSONCompatible {}
 extension Int: JSONCompatible {}
 
 extension JSONCompatible {
-    public func toJSON() throws -> AnyObject {
+    public func toJSON(encodeNulls encodeNulls: Bool) throws -> AnyObject {
         return self as! AnyObject
     }
 }

--- a/JSONCodable/JSONCodable.swift
+++ b/JSONCodable/JSONCodable.swift
@@ -19,6 +19,7 @@ extension Double: JSONCompatible {}
 extension Float: JSONCompatible {}
 extension Bool: JSONCompatible {}
 extension Int: JSONCompatible {}
+extension NSNull: JSONCompatible {}
 
 extension JSONCompatible {
     public func toJSON(encodeNulls encodeNulls: Bool) throws -> AnyObject {

--- a/JSONCodable/JSONEncodable.swift
+++ b/JSONCodable/JSONEncodable.swift
@@ -204,8 +204,8 @@ public class JSONEncoder {
         let result = try array.toJSON(encodeNulls: encodeNullValues)
         object[key] = result
     }
-    private func encode(array: JSONArray, key: String) throws {
         guard array.count > 0 && array.elementsAreJSONEncodable() else {
+    func encode(array: JSONArray, key: String) throws {
             return
         }
         let encodable = array.elementsMadeJSONEncodable()
@@ -267,8 +267,8 @@ public class JSONEncoder {
         let result = try dictionary.toJSON(encodeNulls: encodeNullValues)
         object[key] = result
     }
-    private func encode(dictionary: JSONDictionary, key: String) throws {
         guard dictionary.count > 0 && dictionary.valuesAreJSONEncodable() else {
+    func encode(dictionary: JSONDictionary, key: String) throws {
             return
         }
         let encodable = dictionary.valuesMadeJSONEncodable()

--- a/JSONCodable/JSONEncodable.swift
+++ b/JSONCodable/JSONEncodable.swift
@@ -136,6 +136,7 @@ public extension Dictionary {//where Key: String, Value: JSONEncodable {
 public class JSONEncoder {
     var object = JSONObject()
     public var encodeNullValues = false
+    public var encodeEmptyCollections = false
     
     public static func create(@noescape setup: (encoder: JSONEncoder) throws -> Void) rethrows -> JSONObject {
         let encoder = JSONEncoder()
@@ -191,21 +192,21 @@ public class JSONEncoder {
     
     // [JSONEncodable]
     public func encode<Encodable: JSONEncodable>(array: [Encodable], key: String) throws {
-        guard array.count > 0 else {
+        guard array.count > 0 || encodeEmptyCollections else {
             return
         }
         let result = try array.toJSON(encodeNulls: encodeNullValues)
         object[key] = result
     }
     public func encode(array: [JSONEncodable], key: String) throws {
-        guard array.count > 0 else {
+        guard array.count > 0 || encodeEmptyCollections else {
             return
         }
         let result = try array.toJSON(encodeNulls: encodeNullValues)
         object[key] = result
     }
-        guard array.count > 0 && array.elementsAreJSONEncodable() else {
     func encode(array: JSONArray, key: String) throws {
+        guard (array.count > 0 || encodeEmptyCollections) && array.elementsAreJSONEncodable() else {
             return
         }
         let encodable = array.elementsMadeJSONEncodable()
@@ -219,7 +220,7 @@ public class JSONEncoder {
             if encodeNullValues { object[key] = NSNull() }
             return
         }
-        guard actual.count > 0 else {
+        guard actual.count > 0 || encodeEmptyCollections else {
             return
         }
         let result = try actual.toJSON(encodeNulls: encodeNullValues)
@@ -228,7 +229,7 @@ public class JSONEncoder {
     
     // [Enum]
     public func encode<Enum: RawRepresentable>(value: [Enum], key: String) throws {
-        guard value.count > 0 else {
+        guard value.count > 0 || encodeEmptyCollections else {
             return
         }
         let result = try value.flatMap {
@@ -243,7 +244,7 @@ public class JSONEncoder {
             if encodeNullValues { object[key] = NSNull() }
             return
         }
-        guard actual.count > 0 else {
+        guard actual.count > 0 || encodeEmptyCollections else {
             return
         }
         let result = try actual.flatMap {
@@ -254,21 +255,21 @@ public class JSONEncoder {
     
     // [String:JSONEncodable]
     public func encode<Encodable: JSONEncodable>(dictionary: [String:Encodable], key: String) throws {
-        guard dictionary.count > 0 else {
+        guard dictionary.count > 0 || encodeEmptyCollections else {
             return
         }
         let result = try dictionary.toJSON(encodeNulls: encodeNullValues)
         object[key] = result
     }
     public func encode(dictionary: [String:JSONEncodable], key: String) throws {
-        guard dictionary.count > 0 else {
+        guard dictionary.count > 0  || encodeEmptyCollections else {
             return
         }
         let result = try dictionary.toJSON(encodeNulls: encodeNullValues)
         object[key] = result
     }
-        guard dictionary.count > 0 && dictionary.valuesAreJSONEncodable() else {
     func encode(dictionary: JSONDictionary, key: String) throws {
+        guard (dictionary.count > 0 || encodeEmptyCollections) && dictionary.valuesAreJSONEncodable() else {
             return
         }
         let encodable = dictionary.valuesMadeJSONEncodable()
@@ -282,7 +283,7 @@ public class JSONEncoder {
             if encodeNullValues { object[key] = NSNull() }
             return
         }
-        guard actual.count > 0 else {
+        guard actual.count > 0 || encodeEmptyCollections else {
             return
         }
         let result = try actual.toJSON(encodeNulls: encodeNullValues)

--- a/JSONCodable/JSONEncodable.swift
+++ b/JSONCodable/JSONEncodable.swift
@@ -152,11 +152,7 @@ public class JSONEncoder {
     */
     
     // JSONEncodable
-    public func encode<Encodable: JSONEncodable>(value: Encodable, key: String) throws {
-        let result = try value.toJSON(encodeNulls: encodeNullValues)
-        object[key] = result
-    }
-    private func encode(value: JSONEncodable, key: String) throws {
+    public func encode(value: JSONEncodable, key: String) throws {
         let result = try value.toJSON(encodeNulls: encodeNullValues)
         object[key] = result
     }

--- a/JSONCodable/JSONString.swift
+++ b/JSONCodable/JSONString.swift
@@ -16,7 +16,7 @@ public extension JSONEncodable {
         case is Bool, is Int, is Float, is Double:
             return String(self)
         default:
-            let json = try toJSON()
+            let json = try toJSON([])
             let data = try NSJSONSerialization.dataWithJSONObject(json, options: NSJSONWritingOptions(rawValue: 0))
             guard let string = NSString(data: data, encoding: NSUTF8StringEncoding) else {
                 return ""

--- a/JSONCodableTests/EnumTests.swift
+++ b/JSONCodableTests/EnumTests.swift
@@ -33,7 +33,7 @@ class EnumTests: XCTestCase {
     }
     
     func testEncodingEnum() {
-        guard let json = try? decodedValue.toJSON() else {
+        guard let json = try? decodedValue.toJSON([]) else {
             XCTFail()
             return
         }
@@ -45,7 +45,7 @@ class EnumTests: XCTestCase {
         
         XCTAssertEqual(castedJSON, encodedValue)
         
-        guard let json2 = try? decodedValue2.toJSON() else {
+        guard let json2 = try? decodedValue2.toJSON([]) else {
             XCTFail()
             return
         }

--- a/JSONCodableTests/Food.swift
+++ b/JSONCodableTests/Food.swift
@@ -38,11 +38,10 @@ extension Food: JSONCodable {
         cuisines = try decoder.decode("cuisines")
     }
     
-    func toJSON(encodeNulls encodeNulls: Bool) throws -> AnyObject {
-        return try JSONEncoder.create({ (encoder) -> Void in
-            encoder.encodeNullValues = encodeNulls
+    func toJSON(options: JSONEncodingOptions) throws -> AnyObject {
+        return try JSONEncoder.create(options) { (encoder) -> Void in
             try encoder.encode(name, key: "name")
             try encoder.encode(cuisines, key: "cuisines")
-        })
+        }
     }
 }

--- a/JSONCodableTests/Food.swift
+++ b/JSONCodableTests/Food.swift
@@ -38,8 +38,9 @@ extension Food: JSONCodable {
         cuisines = try decoder.decode("cuisines")
     }
     
-    func toJSON() throws -> AnyObject {
+    func toJSON(encodeNulls encodeNulls: Bool) throws -> AnyObject {
         return try JSONEncoder.create({ (encoder) -> Void in
+            encoder.encodeNullValues = encodeNulls
             try encoder.encode(name, key: "name")
             try encoder.encode(cuisines, key: "cuisines")
         })

--- a/JSONCodableTests/Fruit.swift
+++ b/JSONCodableTests/Fruit.swift
@@ -30,11 +30,13 @@ extension Fruit: JSONCodable {
         color = try decoder.decode("color")
     }
     
-    func toJSON(encodeNulls encodeNulls: Bool) throws -> AnyObject {
-        return try JSONEncoder.create({ (encoder) -> Void in
-            encoder.encodeNullValues = encodeNulls
+    func toJSON(options: JSONEncodingOptions) throws -> AnyObject {
+        return try JSONEncoder.create(options) { (encoder) -> Void in
+            NSLog("a")
             try encoder.encode(name, key: "name")
+            NSLog("b")
             try encoder.encode(color, key: "color")
-        })
+            NSLog("c")
+        }
     }
 }

--- a/JSONCodableTests/Fruit.swift
+++ b/JSONCodableTests/Fruit.swift
@@ -30,8 +30,9 @@ extension Fruit: JSONCodable {
         color = try decoder.decode("color")
     }
     
-    func toJSON() throws -> AnyObject {
+    func toJSON(encodeNulls encodeNulls: Bool) throws -> AnyObject {
         return try JSONEncoder.create({ (encoder) -> Void in
+            encoder.encodeNullValues = encodeNulls
             try encoder.encode(name, key: "name")
             try encoder.encode(color, key: "color")
         })

--- a/JSONCodableTests/HelperTests.swift
+++ b/JSONCodableTests/HelperTests.swift
@@ -24,10 +24,10 @@ class HelperTests: XCTestCase {
 		let notEncodableArray:[NotEncodable] = [NotEncodable()]
 		XCTAssert(!notEncodableArray.elementsAreJSONEncodable(), "Array of type [NotEncodable] should not be encodable")
 
-		let _ = try? JSONEncoder.create({ (encoder) -> Void in
+		let _ = try? JSONEncoder.create([]) { (encoder) -> Void in
 			try encoder.encode(intArray, key: "intArray")
 			try encoder.encode(encodableArray, key: "encodableArray")
-		})
+		}
 
 	}
 
@@ -41,10 +41,10 @@ class HelperTests: XCTestCase {
 		let notEncodableDict:[String:NotEncodable] = ["a":NotEncodable()]
 		XCTAssert(!notEncodableDict.valuesAreJSONEncodable(), "Dictionary of type [String:NotEncodable] should not be encodable")
 
-		let _ = try? JSONEncoder.create({ (encoder) -> Void in
+		let _ = try? JSONEncoder.create([]) { (encoder) -> Void in
 			try encoder.encode(intDict, key: "intArray")
 			try encoder.encode(encodableDict, key: "encodableArray")
-		})
+		}
 	}
     
 }

--- a/JSONCodableTests/ImageAsset.swift
+++ b/JSONCodableTests/ImageAsset.swift
@@ -19,11 +19,11 @@ func ==(lhs: ImageAsset, rhs: ImageAsset) -> Bool {
 }
 
 extension ImageAsset: JSONEncodable {
-    func toJSON(encodeNulls encodeNulls: Bool) throws -> AnyObject {
-        return try JSONEncoder.create({ (encoder) -> Void in
+    func toJSON(options: JSONEncodingOptions) throws -> AnyObject {
+        return try JSONEncoder.create(options) { (encoder) -> Void in
             try encoder.encode(name, key: "name")
             try encoder.encode(uri, key: "uri", transformer: JSONTransformers.StringToNSURL)
-        })
+        }
     }
 }
 

--- a/JSONCodableTests/ImageAsset.swift
+++ b/JSONCodableTests/ImageAsset.swift
@@ -19,7 +19,7 @@ func ==(lhs: ImageAsset, rhs: ImageAsset) -> Bool {
 }
 
 extension ImageAsset: JSONEncodable {
-    func toJSON() throws -> AnyObject {
+    func toJSON(encodeNulls encodeNulls: Bool) throws -> AnyObject {
         return try JSONEncoder.create({ (encoder) -> Void in
             try encoder.encode(name, key: "name")
             try encoder.encode(uri, key: "uri", transformer: JSONTransformers.StringToNSURL)

--- a/JSONCodableTests/RegularTests.swift
+++ b/JSONCodableTests/RegularTests.swift
@@ -19,8 +19,8 @@ class RegularTests: XCTestCase {
             "address": "1 Infinite Loop, Cupertino, CA"
         ],
         "friends": [
-            ["id": 27, "full_name": "Bob Jefferson"],
-            ["id": 29, "full_name": "Jen Jackson"]
+            ["id": 27, "full_name": "Bob Jefferson", "friends": []],
+            ["id": 29, "full_name": "Jen Jackson", "friends": []]
         ]
     ]
     
@@ -33,8 +33,8 @@ class RegularTests: XCTestCase {
             "address": "1 Infinite Loop, Cupertino, CA"
         ],
         "friends": [
-            ["id": 27, "full_name": "Bob Jefferson", "email": NSNull(), "company": NSNull()],
-            ["id": 29, "full_name": "Jen Jackson", "email": NSNull(), "company": NSNull()]
+            ["id": 27, "full_name": "Bob Jefferson", "email": NSNull(), "company": NSNull(), "friends": []],
+            ["id": 29, "full_name": "Jen Jackson", "email": NSNull(), "company": NSNull(), "friends": []]
         ]
     ]
     let decodedValue = User(
@@ -57,7 +57,7 @@ class RegularTests: XCTestCase {
     }
   
     func testEncodingRegular() {
-        guard let json = try? decodedValue.toJSON() else {
+        guard let json = try? decodedValue.toJSON([]) else {
             XCTFail()
             return
         }
@@ -66,7 +66,7 @@ class RegularTests: XCTestCase {
     }
     
     func testNullEncoding() {
-        guard let json = try? decodedValue.toJSON(encodeNulls: true) else {
+        guard let json = try? decodedValue.toJSON([.EncodeNulls]) else {
             XCTFail()
             return
         }

--- a/JSONCodableTests/RegularTests.swift
+++ b/JSONCodableTests/RegularTests.swift
@@ -23,6 +23,20 @@ class RegularTests: XCTestCase {
             ["id": 29, "full_name": "Jen Jackson"]
         ]
     ]
+    
+    let encodedValueWithNulls = [
+        "id": 24,
+        "full_name": "John Appleseed",
+        "email": "john@appleseed.com",
+        "company": [
+            "name": "Apple",
+            "address": "1 Infinite Loop, Cupertino, CA"
+        ],
+        "friends": [
+            ["id": 27, "full_name": "Bob Jefferson", "email": NSNull(), "company": NSNull()],
+            ["id": 29, "full_name": "Jen Jackson", "email": NSNull(), "company": NSNull()]
+        ]
+    ]
     let decodedValue = User(
         id: 24,
         name: "John Appleseed",
@@ -51,4 +65,21 @@ class RegularTests: XCTestCase {
         XCTAssertEqual(json as! [String : NSObject], encodedValue)
     }
     
+    func testNullEncoding() {
+        guard let json = try? decodedValue.toJSON(encodeNulls: true) else {
+            XCTFail()
+            return
+        }
+        
+        XCTAssertEqual(json as! [String : NSObject], encodedValueWithNulls)
+    }
+    
+    func testNullDecoding() {
+        guard let user = try? User(object: encodedValue) else {
+            XCTFail()
+            return
+        }
+        
+        XCTAssertEqual(user, decodedValue)
+    }
 }

--- a/JSONCodableTests/TransformerTests.swift
+++ b/JSONCodableTests/TransformerTests.swift
@@ -29,7 +29,7 @@ class TransformerTests: XCTestCase {
     }
     
     func testEncodingTransformer() {
-        guard let json = try? decodedValue.toJSON() else {
+        guard let json = try? decodedValue.toJSON([]) else {
             XCTFail()
             return
         }

--- a/JSONCodableTests/User.swift
+++ b/JSONCodableTests/User.swift
@@ -26,8 +26,9 @@ func ==(lhs: User, rhs: User) -> Bool {
 }
 
 extension User: JSONEncodable {
-    func toJSON() throws -> AnyObject {
+    func toJSON(encodeNulls encodeNulls: Bool) throws -> AnyObject {
         return try JSONEncoder.create({ (encoder) -> Void in
+            encoder.encodeNullValues = encodeNulls
             try encoder.encode(id, key: "id")
             try encoder.encode(name, key: "full_name")
             try encoder.encode(email, key: "email")

--- a/JSONCodableTests/User.swift
+++ b/JSONCodableTests/User.swift
@@ -26,15 +26,14 @@ func ==(lhs: User, rhs: User) -> Bool {
 }
 
 extension User: JSONEncodable {
-    func toJSON(encodeNulls encodeNulls: Bool) throws -> AnyObject {
-        return try JSONEncoder.create({ (encoder) -> Void in
-            encoder.encodeNullValues = encodeNulls
+    func toJSON(options: JSONEncodingOptions) throws -> AnyObject {
+        return try JSONEncoder.create(options) { (encoder) -> Void in
             try encoder.encode(id, key: "id")
             try encoder.encode(name, key: "full_name")
             try encoder.encode(email, key: "email")
             try encoder.encode(company, key: "company")
             try encoder.encode(friends, key: "friends")
-        })
+        }
     }
 }
 


### PR DESCRIPTION
There are some situations where not encoding a property, or encoding it with a null value will result in different behaviours.

So I've added the ability to do this while trying to keep backward compatibility.
