### PR TITLE
Adds the ability to inflate model with property of type [String: JSONDecodable]

### DIFF
--- a/JSONCodable/JSONDecodable.swift
+++ b/JSONCodable/JSONDecodable.swift
@@ -252,6 +252,36 @@ public class JSONDecoder {
         return dictionary
     }
     
+    // [String:JSONDecodable]
+    public func decode<Element: JSONDecodable>(key: String) throws -> [String: Element] {
+        guard let value = get(key) else {
+            throw JSONDecodableError.MissingTypeError(key: key)
+        }
+        guard let dictionary = value as? [String: JSONObject] else {
+            throw JSONDecodableError.IncompatibleTypeError(key: key, elementType: value.dynamicType, expectedType: [String: Element].self)
+        }
+        var decoded = [String: Element]()
+        try dictionary.forEach {
+            decoded[$0] = try Element(object: $1)
+        }
+        return decoded
+    }
+    
+    // [String:JSONDecodable]?
+    public func decode<Element: JSONDecodable>(key: String) throws -> [String: Element]? {
+        guard let value = get(key) else {
+            return nil
+        }
+        guard let dictionary = value as? [String: JSONObject] else {
+            throw JSONDecodableError.IncompatibleTypeError(key: key, elementType: value.dynamicType, expectedType: [String: Element].self)
+        }
+        var decoded = [String: Element]()
+        try dictionary.forEach {
+            decoded[$0] = try Element(object: $1)
+        }
+        return decoded
+    }
+    
     // JSONTransformable
     public func decode<EncodedType, DecodedType>(key: String, transformer: JSONTransformer<EncodedType, DecodedType>) throws -> DecodedType {
         guard let value = get(key) else {

--- a/JSONCodableTests/RegularTests.swift
+++ b/JSONCodableTests/RegularTests.swift
@@ -21,7 +21,8 @@ class RegularTests: XCTestCase {
         "friends": [
             ["id": 27, "full_name": "Bob Jefferson"],
             ["id": 29, "full_name": "Jen Jackson"]
-        ]
+        ],
+        "friendsLookup": ["Bob Jefferson": ["id": 27, "full_name": "Bob Jefferson"]]
     ]
     let decodedValue = User(
         id: 24,
@@ -29,9 +30,11 @@ class RegularTests: XCTestCase {
         email: "john@appleseed.com",
         company: Company(name: "Apple", address: "1 Infinite Loop, Cupertino, CA"),
         friends: [
-            User(id: 27, name: "Bob Jefferson", email: nil, company: nil, friends: []),
-            User(id: 29, name: "Jen Jackson", email: nil, company: nil, friends: [])
-        ])
+            User(id: 27, name: "Bob Jefferson", email: nil, company: nil, friends: [], friendsLookup: nil),
+            User(id: 29, name: "Jen Jackson", email: nil, company: nil, friends: [], friendsLookup: nil)
+        ],
+        friendsLookup: ["Bob Jefferson":  User(id: 27, name: "Bob Jefferson", email: nil, company: nil, friends: [], friendsLookup: nil)]
+    )
 
     func testDecodingRegular() {
         guard let user = try? User(object: encodedValue) else {
@@ -50,5 +53,4 @@ class RegularTests: XCTestCase {
         
         XCTAssertEqual(json as! [String : NSObject], encodedValue)
     }
-    
 }

--- a/JSONCodableTests/User.swift
+++ b/JSONCodableTests/User.swift
@@ -15,6 +15,7 @@ struct User: Equatable {
     var email: String?
     var company: Company?
     var friends: [User] = []    
+    var friendsLookup: [String: User]?
 }
 
 func ==(lhs: User, rhs: User) -> Bool {
@@ -33,6 +34,7 @@ extension User: JSONEncodable {
             try encoder.encode(email, key: "email")
             try encoder.encode(company, key: "company")
             try encoder.encode(friends, key: "friends")
+            try encoder.encode(friendsLookup, key: "friendsLookup")
         })
     }
 }
@@ -45,5 +47,6 @@ extension User: JSONDecodable {
         email = try decoder.decode("email")
         company = try decoder.decode("company")
         friends = try decoder.decode("friends")
+        friendsLookup = try decoder.decode("friendsLookup")
     }
 }


### PR DESCRIPTION
There are a number of cases where it would make sense for the server to send down dictionaries of type [String: JSONDecodable](as opposed to the currently supported [String: JSONCompatible]).

This PR adds support to decode and encode these value types.
