### PR TITLE
Added support for swift 3.0 (DEVELOPMENT-SNAPSHOT-2016-03-24-a).

### DIFF
--- a/JSONCodable/JSONDecodable.swift
+++ b/JSONCodable/JSONDecodable.swift
@@ -9,8 +9,12 @@
 import Foundation
 
 // Decoding Errors
+#if !swift(>=3.0)
+    typealias ErrorProtocol = ErrorType
+#endif
 
-public enum JSONDecodableError: ErrorType, CustomStringConvertible {
+
+public enum JSONDecodableError: ErrorProtocol, CustomStringConvertible {
     case MissingTypeError(
         key: String
     )
@@ -97,8 +101,12 @@ public class JSONDecoder {
     }
     
     private func get(key: String) -> AnyObject? {
+        #if !swift(>=3.0)
         let keys = key.stringByReplacingOccurrencesOfString("[", withString: ".[")
-                      .componentsSeparatedByString(".")
+            .componentsSeparatedByString(".")
+        #else
+        let keys = key.replacingOccurrences(of: "[", with: ".[").componentsSeparated(by: ".")
+        #endif
         
         let result = keys.reduce(object as AnyObject?) {
             value, key in

--- a/JSONCodable/JSONEncodable.swift
+++ b/JSONCodable/JSONEncodable.swift
@@ -7,8 +7,12 @@
 //
 
 // Encoding Errors
+#if !swift(>=3.0)
+    typealias ErrorProtocol = ErrorType
+#endif
 
-public enum JSONEncodableError: ErrorType, CustomStringConvertible {
+
+public enum JSONEncodableError: ErrorProtocol, CustomStringConvertible {
     case IncompatibleTypeError(
         elementType: Any.Type
     )
@@ -52,9 +56,15 @@ public extension JSONEncodable {
     func toJSON() throws -> AnyObject {
         let mirror = Mirror(reflecting: self)
         
+        #if !swift(>=3.0)
         guard let style = mirror.displayStyle where style == .Struct || style == .Class else {
             throw JSONEncodableError.IncompatibleTypeError(elementType: self.dynamicType)
         }
+        #else
+        guard let style = mirror.displayStyle where style == .`struct` || style == .`class` else {
+            throw JSONEncodableError.IncompatibleTypeError(elementType: self.dynamicType)
+        }
+        #endif
         
         return try JSONEncoder.create({ (encoder) -> Void in
             // loop through all properties (instance variables)

--- a/JSONCodable/JSONTransformer.swift
+++ b/JSONCodable/JSONTransformer.swift
@@ -37,8 +37,14 @@ public struct JSONTransformers {
         decoding: {NSURL(string: $0)},
         encoding: {$0.absoluteString})
 
+    #if !swift(>=3.0)
     public static let StringToNSDate = JSONTransformer<String, NSDate>(
         decoding: {dateTimeFormatter.dateFromString($0)},
         encoding: {dateTimeFormatter.stringFromDate($0)})
+    #else
+    public static let StringToNSDate = JSONTransformer<String, NSDate>(
+        decoding: {dateTimeFormatter.date(from: $0)},
+        encoding: {dateTimeFormatter.string(from:$0)})
+    #endif
 
 }


### PR DESCRIPTION
Hi,

I added support for swift 3.0 (DEVELOPMENT-SNAPSHOT-2016-03-24-a) using macros checking the swift version, so should work both with 2.2 and (current) 3.0 dev.

Changes are mostly about keeping up with the swift-3-api-guidelines induced changes.
