### PR TITLE
Better readability fortransformers

### DIFF
--- a/JSONCodable/JSONTransformer.swift
+++ b/JSONCodable/JSONTransformer.swift
@@ -32,18 +32,28 @@ private let dateTimeFormatter: NSDateFormatter = {
     return formatter
 }()
 
-public struct JSONTransformers {
-    public static let StringToNSURL = JSONTransformer<String, NSURL>(
+struct JSONTransformers {
+    static let StringToNSURL = JSONTransformer<String, NSURL>(
         decoding: {NSURL(string: $0)},
         encoding: {$0.absoluteString})
 
     #if !swift(>=3.0)
-    public static let StringToNSDate = JSONTransformer<String, NSDate>(
+    static let StringToNSDate = JSONTransformer<String, NSDate>(
         decoding: {dateTimeFormatter.dateFromString($0)},
         encoding: {dateTimeFormatter.stringFromDate($0)})
     #else
-    public static let StringToNSDate = JSONTransformer<String, NSDate>(
+    static let StringToNSDate = JSONTransformer<String, NSDate>(
         decoding: {dateTimeFormatter.date(from: $0)},
         encoding: {dateTimeFormatter.string(from: $0)})
     #endif
+}
+
+public extension JSONTransformer {
+    static func stringToURL() -> JSONTransformer<String, NSURL>{
+        return JSONTransformers.StringToNSURL
+    }
+    
+    static func stringToDate() -> JSONTransformer<String, NSDate>{
+        return JSONTransformers.StringToNSDate
+    }
 }

--- a/JSONCodable/JSONTransformer.swift
+++ b/JSONCodable/JSONTransformer.swift
@@ -33,16 +33,16 @@ private let dateTimeFormatter: NSDateFormatter = {
 }()
 
 public struct JSONTransformers {
-    static let StringToNSURL = JSONTransformer<String, NSURL>(
+    public static let StringToNSURL = JSONTransformer<String, NSURL>(
         decoding: {NSURL(string: $0)},
         encoding: {$0.absoluteString})
 
     #if !swift(>=3.0)
-    static let StringToNSDate = JSONTransformer<String, NSDate>(
+    public static let StringToNSDate = JSONTransformer<String, NSDate>(
         decoding: {dateTimeFormatter.dateFromString($0)},
         encoding: {dateTimeFormatter.stringFromDate($0)})
     #else
-    static let StringToNSDate = JSONTransformer<String, NSDate>(
+    public static let StringToNSDate = JSONTransformer<String, NSDate>(
         decoding: {dateTimeFormatter.date(from: $0)},
         encoding: {dateTimeFormatter.string(from: $0)})
     #endif

--- a/JSONCodable/JSONTransformer.swift
+++ b/JSONCodable/JSONTransformer.swift
@@ -32,7 +32,7 @@ private let dateTimeFormatter: NSDateFormatter = {
     return formatter
 }()
 
-struct JSONTransformers {
+public struct JSONTransformers {
     static let StringToNSURL = JSONTransformer<String, NSURL>(
         decoding: {NSURL(string: $0)},
         encoding: {$0.absoluteString})
@@ -49,11 +49,11 @@ struct JSONTransformers {
 }
 
 public extension JSONTransformer {
-    static func stringToURL() -> JSONTransformer<String, NSURL>{
+    static var stringToURL: JSONTransformer<String, NSURL>{
         return JSONTransformers.StringToNSURL
     }
     
-    static func stringToDate() -> JSONTransformer<String, NSDate>{
+    static var stringToDate: JSONTransformer<String, NSDate>{
         return JSONTransformers.StringToNSDate
     }
 }


### PR DESCRIPTION
Changes default transformers to static function to make use of Swift type inference

``` swift
date = try decoder.decode("date", transformer: JSONTransformers.StringToNSDate)
```

becomes 

``` swift
date = try decoder.decode("date", transformer: .stringToDate())
```

This improves readability while extending this pattern is easy. Just create an extension on  `JSONTransformer` for every custom transformer.
