### PR TITLE
Explicitly coerce to Any (eliminate Swift 3.0.1 compiler warning)

### DIFF
--- a/JSONCodable/JSONDecodable.swift
+++ b/JSONCodable/JSONDecodable.swift
@@ -139,7 +139,7 @@ public class JSONDecoder {
     
     // JSONCompatible?
     public func decode<Compatible: JSONCompatible>(_ key: String) throws -> Compatible? {
-        return (get(key) ?? object[key]) as? Compatible
+        return (get(key) ?? object[key] as Any) as? Compatible
     }
     
     // JSONDecodable


### PR DESCRIPTION
This should be no change in behavior, and eliminates a warning emitted by the Swift 3.0.1 compiler (in Xcode 8, beta 3)

![screen shot 2016-10-21 at 4 44 46 pm](https://cloud.githubusercontent.com/assets/442307/19614954/c4b8bba2-97ae-11e6-9b93-2857dc3405cd.png)
