### PR TITLE
remove JSONCodable protocol

### DIFF
--- a/JSONCodable/JSONCodable.swift
+++ b/JSONCodable/JSONCodable.swift
@@ -6,10 +6,6 @@
 //  Copyright © 2015 matthewcheok. All rights reserved.
 //
 
-// convenience protocol
-
-public protocol JSONCodable: JSONEncodable, JSONDecodable {}
-
 // JSONCompatible - valid types in JSON
 
 public protocol JSONCompatible: JSONEncodable {}

--- a/JSONCodableTests/ClassInheritance.swift
+++ b/JSONCodableTests/ClassInheritance.swift
@@ -9,7 +9,7 @@
 import Foundation
 import JSONCodable
 
-class Parent : JSONCodable
+class Parent : JSONEncodable, JSONDecodable
 {
     var parentProperty1:String = "parent1"
     var parentProperty2:String = "parent2"

--- a/JSONCodableTests/Food.swift
+++ b/JSONCodableTests/Food.swift
@@ -30,7 +30,7 @@ func ==(lhs: Food, rhs: Food) -> Bool {
     return lhs.name == rhs.name && lhs.cuisines == rhs.cuisines
 }
 
-extension Food: JSONCodable {
+extension Food: JSONEncodable, JSONDecodable {
     init(object: JSONObject) throws {
         let decoder = JSONDecoder(object: object)
         name = try decoder.decode("name")

--- a/JSONCodableTests/Fruit.swift
+++ b/JSONCodableTests/Fruit.swift
@@ -22,7 +22,7 @@ func ==(lhs: Fruit, rhs: Fruit) -> Bool {
   return lhs.name == rhs.name && lhs.color == rhs.color
 }
 
-extension Fruit: JSONCodable {
+extension Fruit: JSONEncodable, JSONDecodable {
   init(object: JSONObject) throws {
     let decoder = JSONDecoder(object: object)
     name = try decoder.decode("name")


### PR DESCRIPTION
I've bumped into a problem while using xcode9.
Error I was getting was:

> 'JSONDecoder' is ambiguous for type lookup in this context

The only way to fix this is to put class in proper namespace by add prefix `JSONCodable` like `JSONCodable.JSONDecoder`, but there is a problem that compiler want to use protocol called the same, not lib name

the only idea I've figure out is to remove this protocol
